### PR TITLE
SDR thread and backgrounding options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ POTHOS_MODULE_UTIL(
         DemoController.cpp
         Logger.cpp
         SDRInfo.cpp
+        SDRBlockThread.cpp
     LIBRARIES ${SoapySDR_LIBRARIES}
     DESTINATION sdr
     DOC_SOURCES

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,5 +1,11 @@
 This this the changelog file for the Pothos SDR toolkit.
 
+Release 0.3.2 (pending)
+==========================
+
+- Added setting background thread configuration options
+- Added event squashing option for excess setter events
+
 Release 0.3.1 (2016-05-10)
 ==========================
 

--- a/SDRBlock.cpp
+++ b/SDRBlock.cpp
@@ -13,6 +13,9 @@
 #include <cassert>
 
 SDRBlock::SDRBlock(const int direction, const Pothos::DType &dtype, const std::vector<size_t> &chs):
+    _settersBlock(true),
+    _activateBlocks(true),
+    _eventSquash(false),
     _autoActivate(true),
     _direction(direction),
     _dtype(dtype),
@@ -26,6 +29,10 @@ SDRBlock::SDRBlock(const int direction, const Pothos::DType &dtype, const std::v
     if (SoapySDR::getABIVersion() != SOAPY_SDR_ABI_VERSION) throw Pothos::Exception("SDRBlock::make()",
         Poco::format("Failed ABI check. Pothos SDR %s. Soapy SDR %s. Rebuild the module.",
         std::string(SOAPY_SDR_ABI_VERSION), SoapySDR::getABIVersion()));
+
+    //threading options
+    this->registerCall(this, POTHOS_FCN_TUPLE(SDRBlock, setBackgroundMode));
+    this->registerCall(this, POTHOS_FCN_TUPLE(SDRBlock, enableEventSquash));
 
     //streaming
     this->registerCall(this, POTHOS_FCN_TUPLE(SDRBlock, setupDevice));

--- a/SDRBlock.cpp
+++ b/SDRBlock.cpp
@@ -14,7 +14,7 @@
 
 SDRBlock::SDRBlock(const int direction, const Pothos::DType &dtype, const std::vector<size_t> &chs):
     _settersBlock(true),
-    _activateBlocks(true),
+    _activateWaits(true),
     _eventSquash(false),
     _autoActivate(true),
     _direction(direction),

--- a/SDRBlock.cpp
+++ b/SDRBlock.cpp
@@ -13,8 +13,8 @@
 #include <cassert>
 
 SDRBlock::SDRBlock(const int direction, const Pothos::DType &dtype, const std::vector<size_t> &chs):
-    _settersBlock(true),
-    _activateWaits(true),
+    _backgrounding(false),
+    _activateWaits(false),
     _eventSquash(false),
     _autoActivate(true),
     _direction(direction),
@@ -31,8 +31,8 @@ SDRBlock::SDRBlock(const int direction, const Pothos::DType &dtype, const std::v
         std::string(SOAPY_SDR_ABI_VERSION), SoapySDR::getABIVersion()));
 
     //threading options
-    this->registerCall(this, POTHOS_FCN_TUPLE(SDRBlock, setBackgroundMode));
-    this->registerCall(this, POTHOS_FCN_TUPLE(SDRBlock, enableEventSquash));
+    this->registerCall(this, POTHOS_FCN_TUPLE(SDRBlock, setCallingMode));
+    this->registerCall(this, POTHOS_FCN_TUPLE(SDRBlock, setEventSquash));
 
     //streaming
     this->registerCall(this, POTHOS_FCN_TUPLE(SDRBlock, setupDevice));

--- a/SDRBlock.cpp
+++ b/SDRBlock.cpp
@@ -175,7 +175,7 @@ SDRBlock::SDRBlock(const int direction, const Pothos::DType &dtype, const std::v
 
     //start eval thread
     _evalThreadDone = false;
-    _evalError = false;
+    _evalErrorValid = false;
     _evalThread = std::thread(&SDRBlock::evalThreadLoop, this);
 }
 

--- a/SDRBlock.hpp
+++ b/SDRBlock.hpp
@@ -26,10 +26,10 @@ public:
      ******************************************************************/
 
     //! Evaluate setters in a background thread as to not block
-    void setBackgroundMode(const std::string &mode);
+    void setCallingMode(const std::string &mode);
 
     //! Once activated, allow settings to queue and discard old ones
-    void enableEventSquash(const bool enable);
+    void setEventSquash(const bool enable);
 
     Pothos::Object opaqueCallHandler(const std::string &name, const Pothos::Object *inputArgs, const size_t numArgs);
 
@@ -269,7 +269,7 @@ protected:
     bool isReady(void);
     void emitActivationSignals(void);
 
-    bool _settersBlock;
+    bool _backgrounding;
     bool _activateWaits;
     bool _eventSquash;
     bool _autoActivate;

--- a/SDRBlock.hpp
+++ b/SDRBlock.hpp
@@ -270,7 +270,7 @@ protected:
     void emitActivationSignals(void);
 
     bool _settersBlock;
-    bool _activateBlocks;
+    bool _activateWaits;
     bool _eventSquash;
     bool _autoActivate;
     const int _direction;

--- a/SDRBlock.hpp
+++ b/SDRBlock.hpp
@@ -24,6 +24,13 @@ public:
     /*******************************************************************
      * Delayed method dispatch
      ******************************************************************/
+
+    //! Evaluate setters in a background thread as to not block
+    void setBackgroundMode(const std::string &mode);
+
+    //! Once activated, allow settings to queue and discard old ones
+    void enableEventSquash(const bool enable);
+
     Pothos::Object opaqueCallHandler(const std::string &name, const Pothos::Object *inputArgs, const size_t numArgs);
 
     /*******************************************************************
@@ -262,6 +269,9 @@ protected:
     bool isReady(void);
     void emitActivationSignals(void);
 
+    bool _settersBlock;
+    bool _activateBlocks;
+    bool _eventSquash;
     bool _autoActivate;
     const int _direction;
     const Pothos::DType _dtype;

--- a/SDRBlock.hpp
+++ b/SDRBlock.hpp
@@ -6,6 +6,9 @@
 #include <SoapySDR/Device.hpp>
 #include <future>
 #include <thread>
+#include <mutex>
+#include <atomic>
+#include <condition_variable>
 
 class SDRBlock : public Pothos::Block
 {
@@ -269,7 +272,16 @@ protected:
     bool _enableStatus;
     std::thread _statusMonitor;
 
+    //evaluation thread
+    std::mutex _callMutex;
+    std::mutex _argsMutex;
+    std::condition_variable _cond;
     std::vector<std::pair<std::string, Pothos::ObjectVector>> _cachedArgs;
+    std::thread _evalThread;
+    void evalThreadLoop(void);
+    std::exception_ptr _evalError;
+    std::atomic<bool> _evalThreadDone;
+    std::atomic<bool> _evalErrorValid;
     std::shared_future<SoapySDR::Device *> _deviceFuture;
 
     std::vector<Pothos::ObjectKwargs> _pendingLabels;

--- a/SDRBlock.hpp
+++ b/SDRBlock.hpp
@@ -283,7 +283,6 @@ protected:
     std::thread _statusMonitor;
 
     //evaluation thread
-    std::mutex _callMutex;
     std::mutex _argsMutex;
     std::condition_variable _cond;
     std::vector<std::pair<std::string, Pothos::ObjectVector>> _cachedArgs;

--- a/SDRBlockDesc.hpp
+++ b/SDRBlockDesc.hpp
@@ -264,7 +264,7 @@
  * |option [Synchronous calls] "SYNCHRONOUS"
  * |option [Activate waits] "ACTIVATE_WAITS"
  * |option [Activate throws] "ACTIVATE_THROWS"
- * |default "SYNCHRONOUS"
+ * |default "ACTIVATE_WAITS"
  * |preview disable
  * |tab Advanced
  *

--- a/SDRBlockDesc.hpp
+++ b/SDRBlockDesc.hpp
@@ -260,11 +260,11 @@
  * |param backgroundMode[Background mode] Optional background threading for initialization.
  * When enabled, setter calls will not block, they will be evaluated in a background thread.
  * A secondary part of this option controls how the activate() call will handle the case
- * when settings have not yet completed. The options for activate are to block or error out.
- * |option [Setters block] "SETTERS_BLOCK"
- * |option [Activate blocks] "ACTIVATE_BLOCKS"
+ * when settings have not yet completed. The options for activate are to wait or to throw.
+ * |option [Synchronous calls] "SYNCHRONOUS"
+ * |option [Activate waits] "ACTIVATE_WAITS"
  * |option [Activate throws] "ACTIVATE_THROWS"
- * |default "SETTERS_BLOCK"
+ * |default "SYNCHRONOUS"
  * |preview disable
  * |tab Advanced
  *

--- a/SDRBlockDesc.hpp
+++ b/SDRBlockDesc.hpp
@@ -257,7 +257,7 @@
  * |preview valid
  * |tab Advanced
  *
- * |param backgroundMode[Background mode] Optional background threading for initialization.
+ * |param callingMode[Calling mode] Optional background threading for initialization.
  * When enabled, setter calls will not block, they will be evaluated in a background thread.
  * A secondary part of this option controls how the activate() call will handle the case
  * when settings have not yet completed. The options for activate are to wait or to throw.
@@ -280,7 +280,8 @@
  * |tab Advanced
  *
  * |factory @PATH@(dtype, channels)
- * |initializer setBackgroundMode(backgroundMode)
+ * |setter setCallingMode(callingMode)
+ * |setter setEventSquash(eventSquash)
  * |initializer setupDevice(deviceArgs)
  * |initializer setupStream(streamArgs)
  * |initializer setFrontendMap(frontendMap)
@@ -299,5 +300,4 @@
  * |setter setEnableStatus(enableStatus)
  * |setter setGlobalSettings(globalSettings)
  * |setter setChannelSettings(channelSettings)
- * |setter enableEventSquash(eventSquash)
  **********************************************************************/

--- a/SDRBlockDesc.hpp
+++ b/SDRBlockDesc.hpp
@@ -257,7 +257,30 @@
  * |preview valid
  * |tab Advanced
  *
+ * |param backgroundMode[Background mode] Optional background threading for initialization.
+ * When enabled, setter calls will not block, they will be evaluated in a background thread.
+ * A secondary part of this option controls how the activate() call will handle the case
+ * when settings have not yet completed. The options for activate are to block or error out.
+ * |option [Setters block] "SETTERS_BLOCK"
+ * |option [Activate blocks] "ACTIVATE_BLOCKS"
+ * |option [Activate throws] "ACTIVATE_THROWS"
+ * |default "SETTERS_BLOCK"
+ * |preview disable
+ * |tab Advanced
+ *
+ * |param eventSquash[Event squashing] Optional squashing of setter calls.
+ * When the block is activated its possible for an upstream block to produce more
+ * setting events than the block can keep up with (example a slider setting the gain).
+ * Only the most recent value is actually desirable to keep and apply to the device.
+ * This option allows intermediate settings to be discarded.
+ * |option [Enable] true
+ * |option [Disable] false
+ * |default false
+ * |preview disable
+ * |tab Advanced
+ *
  * |factory @PATH@(dtype, channels)
+ * |initializer setBackgroundMode(backgroundMode)
  * |initializer setupDevice(deviceArgs)
  * |initializer setupStream(streamArgs)
  * |initializer setFrontendMap(frontendMap)
@@ -276,4 +299,5 @@
  * |setter setEnableStatus(enableStatus)
  * |setter setGlobalSettings(globalSettings)
  * |setter setChannelSettings(channelSettings)
+ * |setter enableEventSquash(eventSquash)
  **********************************************************************/

--- a/SDRBlockThread.cpp
+++ b/SDRBlockThread.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2014-2016 Josh Blum
+// SPDX-License-Identifier: BSL-1.0
+
+#include "SDRBlock.hpp"
+#include <Poco/Format.h>
+#include <Poco/Logger.h>
+#include <Poco/SingletonHolder.h>
+#include <cassert>
+
+/*******************************************************************
+ * Delayed method dispatch
+ ******************************************************************/
+Pothos::Object SDRBlock::opaqueCallHandler(const std::string &name, const Pothos::Object *inputArgs, const size_t numArgs)
+{
+    //try to setup the device future first
+    if (name == "setupDevice") return Pothos::Block::opaqueCallHandler(name, inputArgs, numArgs);
+
+    //when ready forward the call to the handler
+    if (this->isReady()) return Pothos::Block::opaqueCallHandler(name, inputArgs, numArgs);
+
+    //cache attempted settings when not ready
+    const bool isSetter = (name.size() > 3 and name.substr(0, 3) == "set");
+    if (isSetter) _cachedArgs.push_back(std::make_pair(name, Pothos::ObjectVector(inputArgs, inputArgs+numArgs)));
+    else throw Pothos::Exception("SDRBlock::"+name+"()", "device not ready");
+    return Pothos::Object();
+}
+
+bool SDRBlock::isReady(void)
+{
+    if (_device != nullptr) return true;
+    if (_deviceFuture.wait_for(std::chrono::seconds(0)) != std::future_status::ready) return false;
+    _device = _deviceFuture.get();
+    assert(_device != nullptr);
+
+    //call the cached settings now that the device exists
+    for (const auto &pair : _cachedArgs)
+    {
+        POTHOS_EXCEPTION_TRY
+        {
+            Pothos::Block::opaqueCallHandler(pair.first, pair.second.data(), pair.second.size());
+        }
+        POTHOS_EXCEPTION_CATCH (const Pothos::Exception &ex)
+        {
+            poco_error_f2(Poco::Logger::get("SDRBlock"), "call %s threw: %s", pair.first, ex.displayText());
+        }
+    }
+
+    return true;
+}
+
+/*******************************************************************
+ * Evaluation thread
+ ******************************************************************/
+void SDRBlock::evalThreadLoop(void)
+{
+    while (not _evalThreadDone)
+    {
+        //wait for input settings args
+        std::unique_lock<std::mutex> argsLock(_argsMutex);
+        if (_cachedArgs.empty()) _cond.wait(argsLock);
+        if (_cachedArgs.empty()) continue;
+
+        //pop the most recent setting args
+        std::pair<std::string, Pothos::ObjectVector> current;
+        current = _cachedArgs.front();
+        _cachedArgs.erase(_cachedArgs.begin());
+        argsLock.unlock();
+
+        //make the call in this thread
+        std::lock_guard<std::mutex> callLock(_callMutex);
+        POTHOS_EXCEPTION_TRY
+        {
+            Pothos::Block::opaqueCallHandler(current.first, current.second.data(), current.second.size());
+        }
+        POTHOS_EXCEPTION_CATCH (const Pothos::Exception &ex)
+        {
+            poco_error_f2(Poco::Logger::get("SDRBlock"), "call %s threw: %s", current.first, ex.displayText());
+            _evalError = std::current_exception();
+            _evalErrorValid = true;
+        }
+    }
+}

--- a/SDRBlockThread.cpp
+++ b/SDRBlockThread.cpp
@@ -47,8 +47,8 @@ Pothos::Object SDRBlock::opaqueCallHandler(const std::string &name, const Pothos
     //check for existing errors, throw and clear
     if (_evalErrorValid)
     {
-        std::rethrow_exception(_evalError);
         _evalErrorValid = false;
+        std::rethrow_exception(_evalError);
     }
 
     //put setters into the args cache when blocking is disabled
@@ -76,8 +76,8 @@ bool SDRBlock::isReady(void)
     //check for existing errors, throw and clear
     if (_evalErrorValid)
     {
-        std::rethrow_exception(_evalError);
         _evalErrorValid = false;
+        std::rethrow_exception(_evalError);
     }
 
     //when not blocking, we are ready when all cached args are processed
@@ -131,6 +131,7 @@ void SDRBlock::evalThreadLoop(void)
         POTHOS_EXCEPTION_CATCH (const Pothos::Exception &ex)
         {
             poco_error_f2(Poco::Logger::get("SDRBlock"), "call %s threw: %s", current.first, ex.displayText());
+            argsLock.lock(); //re-lock to set exception
             _evalError = std::current_exception();
             _evalErrorValid = true;
         }

--- a/SDRBlockThread.cpp
+++ b/SDRBlockThread.cpp
@@ -9,6 +9,35 @@
 #include <iostream>
 
 /*******************************************************************
+ * threading configuration
+ ******************************************************************/
+void SDRBlock::setBackgroundMode(const std::string &mode)
+{
+    if (mode == "SETTERS_BLOCK")
+    {
+        _settersBlock = true;
+        _activateBlocks = true;
+    }
+    else if (mode == "ACTIVATE_BLOCKS")
+    {
+        _settersBlock = false;
+        _activateBlocks = true;
+    }
+    else if (mode == "ACTIVATE_THROWS")
+    {
+        _settersBlock = false;
+        _activateBlocks = false;
+    }
+    else throw Pothos::InvalidArgumentException(
+        "SDRBlock::setBackgroundMode("+mode+")", "unknown background mode");
+}
+
+void SDRBlock::enableEventSquash(const bool enable)
+{
+    _eventSquash = enable;
+}
+
+/*******************************************************************
  * Delayed method dispatch
  ******************************************************************/
 Pothos::Object SDRBlock::opaqueCallHandler(const std::string &name, const Pothos::Object *inputArgs, const size_t numArgs)

--- a/SDRBlockThread.cpp
+++ b/SDRBlockThread.cpp
@@ -11,28 +11,28 @@
 /*******************************************************************
  * threading configuration
  ******************************************************************/
-void SDRBlock::setBackgroundMode(const std::string &mode)
+void SDRBlock::setCallingMode(const std::string &mode)
 {
     if (mode == "SYNCHRONOUS")
     {
-        _settersBlock = true;
+        _backgrounding = false;
         _activateWaits = true;
     }
     else if (mode == "ACTIVATE_WAITS")
     {
-        _settersBlock = false;
+        _backgrounding = true;
         _activateWaits = true;
     }
     else if (mode == "ACTIVATE_THROWS")
     {
-        _settersBlock = false;
+        _backgrounding = true;
         _activateWaits = false;
     }
     else throw Pothos::InvalidArgumentException(
         "SDRBlock::setBackgroundMode("+mode+")", "unknown background mode");
 }
 
-void SDRBlock::enableEventSquash(const bool enable)
+void SDRBlock::setEventSquash(const bool enable)
 {
     _eventSquash = enable;
 }
@@ -51,10 +51,10 @@ Pothos::Object SDRBlock::opaqueCallHandler(const std::string &name, const Pothos
         std::rethrow_exception(_evalError);
     }
 
-    //put setters into the args cache when blocking is disabled
-    //or when squashing is enabled during block activation
+    //put setters into the args cache when backgrounding is enabled
+    //or when squashing is enabled but only during block activation
     const bool isSetter = (name.size() > 3 and name.substr(0, 3) == "set");
-    const bool background = not _settersBlock or (_eventSquash and this->isActive());
+    const bool background = _backgrounding or (_eventSquash and this->isActive());
     if (isSetter and background)
     {
         _cachedArgs.emplace_back(name, Pothos::ObjectVector(inputArgs, inputArgs+numArgs));


### PR DESCRIPTION
* Added setting background thread configuration options - initialization calls can be backgrounded optionally but default to blocking which is best for non-gui applications. In addition the activate() call can be configured to block to wait for ready. This allows the SDR blocks to recover and continue streaming after a reload() in the GUI even when the backgrounding is enabled.
* Added event squashing option for excess setter events - good use case is a slider widget which produces tune or set gain events faster than the SDR can handle them. Event squashing only applies the most recent.
* Resolves https://github.com/pothosware/pothos-sdr/issues/11
