### PR TITLE
One-liner to fix crash on topology activation before stream setup

### DIFF
--- a/SDRBlock.cpp
+++ b/SDRBlock.cpp
@@ -857,6 +857,7 @@ void SDRBlock::emitActivationSignals(void)
 void SDRBlock::activate(void)
 {
     if (not this->isReady()) throw Pothos::Exception("SDRSource::activate()", "device not ready");
+    if (not _stream) throw Pothos::Exception("SDRSource::activate()", "stream not set up");
 
     if (_autoActivate)
     {


### PR DESCRIPTION
Noticed segfault because activate() isn't checking the validity of the _stream sptr before attempting to dereference it.